### PR TITLE
Add context

### DIFF
--- a/app/_components/Character.tsx
+++ b/app/_components/Character.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import ItemType from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
+import { ItemType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 import ItemInstanceType from '../_interfaces/InventoryItemInstance.interface';
 import Item from './Item';
 
@@ -33,7 +33,7 @@ export default function Character({
         }
         return (
           <div key={i}>
-            <Item item={itemDefinitions[item]} powerLevel={powerLevel} />
+            <Item itemHash={item} powerLevel={powerLevel} />
           </div>
         );
       });

--- a/app/_components/Character.tsx
+++ b/app/_components/Character.tsx
@@ -1,14 +1,10 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { ItemType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 import ItemInstanceType from '../_interfaces/InventoryItemInstance.interface';
 import Item from './Item';
 
 type Props = {
-  itemDefinitions: {
-    [key: number]: ItemType;
-  };
   itemHashes: number[];
   itemInstanceIds: string[];
   itemInstances: {
@@ -17,7 +13,6 @@ type Props = {
 };
 
 export default function Character({
-  itemDefinitions,
   itemHashes,
   itemInstanceIds,
   itemInstances,
@@ -25,21 +20,15 @@ export default function Character({
   const [itemComponents, setItemComponents] = useState<JSX.Element[]>();
 
   useEffect(() => {
-    if (itemDefinitions) {
-      const itemComponents = itemHashes.map((item, i) => {
-        let powerLevel = undefined;
-        if (itemInstances[itemInstanceIds[i]].primaryStat) {
-          powerLevel = itemInstances[itemInstanceIds[i]].primaryStat.value;
-        }
-        return (
-          <div key={i}>
-            <Item itemHash={item} powerLevel={powerLevel} />
-          </div>
-        );
-      });
-      setItemComponents(itemComponents);
-    }
-  }, [itemDefinitions, itemHashes]);
+    const itemComponents = itemHashes.map((item, i) => {
+      let powerLevel = undefined;
+      if (itemInstances[itemInstanceIds[i]].primaryStat) {
+        powerLevel = itemInstances[itemInstanceIds[i]].primaryStat.value;
+      }
+      return <Item itemHash={item} powerLevel={powerLevel} />;
+    });
+    setItemComponents(itemComponents);
+  }, [itemHashes]);
 
   return <div className="w-100">{itemComponents}</div>;
 }

--- a/app/_components/CharacterContainer.tsx
+++ b/app/_components/CharacterContainer.tsx
@@ -7,13 +7,11 @@ type Props = {
   characterData: {
     [key: string]: CharacterEquipmentType;
   };
-  itemDefinitions: {};
   itemInstances: {};
 };
 
 export default function CharacterContainer({
   characterData,
-  itemDefinitions,
   itemInstances,
 }: Props) {
   const characterIds = Object.keys(characterData);
@@ -34,7 +32,6 @@ export default function CharacterContainer({
         {/* need to add dynamic character names */}
         <p className="text-center">CHARACTER</p>
         <Character
-          itemDefinitions={itemDefinitions}
           itemHashes={itemHashes}
           itemInstanceIds={itemInstanceIds}
           itemInstances={itemInstances}

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useContext } from 'react';
-import DestinyInventoryItemDefinitionContext from '../_context/DestinyInventoryItemDefinitionContext';
+import { DestinyInventoryItemDefinitionContext } from '../_context/DestinyInventoryItemDefinitionContext';
 import { ItemTableType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 
 type Props = {

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -1,24 +1,33 @@
 'use client';
 
-import ItemType from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
+import { useContext } from 'react';
+import DestinyInventoryItemDefinitionContext from '../_context/DestinyInventoryItemDefinitionContext';
+import { ItemTableType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 
 type Props = {
-  item: ItemType;
+  itemHash: number;
   powerLevel?: number;
 };
 
-export default function Item({ item, powerLevel }: Props) {
+export default function Item({ itemHash, powerLevel }: Props) {
+  const definitions: ItemTableType = useContext(
+    DestinyInventoryItemDefinitionContext
+  );
   return (
     <div className="flex mt-8 items-center">
       <img
-        src={`https://bungie.net${item.displayProperties.icon}`}
+        src={`https://bungie.net${definitions[itemHash].displayProperties.icon}`}
         alt=""
         style={{ height: '8em' }}
       />
       <div className="text-center grow">
-        <p className="text-xl">{item.displayProperties.name}</p>
+        <p className="text-xl">
+          {definitions[itemHash].displayProperties.name}
+        </p>
         {powerLevel ? <p className="text-sm bold mt-2">{powerLevel}</p> : null}
-        <p className="text-sm italic mt-2">{item.itemTypeAndTierDisplayName}</p>
+        <p className="text-sm italic mt-2">
+          {definitions[itemHash].itemTypeAndTierDisplayName}
+        </p>
       </div>
     </div>
   );

--- a/app/_context/DestinyInventoryItemDefinitionContext.ts
+++ b/app/_context/DestinyInventoryItemDefinitionContext.ts
@@ -1,5 +1,0 @@
-import { createContext } from 'react';
-
-const DestinyInventoryItemDefinitionContext = createContext();
-
-export default DestinyInventoryItemDefinitionContext;

--- a/app/_context/DestinyInventoryItemDefinitionContext.ts
+++ b/app/_context/DestinyInventoryItemDefinitionContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const DestinyInventoryItemDefinitionContext = createContext();
+
+export default DestinyInventoryItemDefinitionContext;

--- a/app/_context/DestinyInventoryItemDefinitionContext.tsx
+++ b/app/_context/DestinyInventoryItemDefinitionContext.tsx
@@ -1,13 +1,31 @@
-import { createContext } from 'react';
+import { useState, useEffect, createContext, useContext } from 'react';
+import { useManifestStatus } from '../_hooks/useManifestStatus';
+import { get } from 'idb-keyval';
 
-const DestinyInventoryItemDefinitionContext = createContext();
+export const DestinyInventoryItemDefinitionContext = createContext();
 
-export function DestinyInventoryItemDefinitionContextProvider() {
+export function DestinyInventoryItemDefinitionContextProvider(props: any) {
+  const manifestIsLoaded = useManifestStatus();
+  const [itemDefinitions, setItemDefinitions] = useState();
+
+  const getItemDefinitions = async () => {
+    const manifest = await get('manifest');
+    return manifest.DestinyItemInventoryDefinition;
+  };
+
+  useEffect(() => {
+    if (!manifestIsLoaded) return;
+    (async () => {
+      const itemDefinitions = await getItemDefinitions();
+      setItemDefinitions(itemDefinitions);
+    })();
+  }, [manifestIsLoaded]);
+
   return (
-    <DestinyInventoryItemDefinitionContext.Provider
-      value={'placeholder'}
-    ></DestinyInventoryItemDefinitionContext.Provider>
+    <>
+      <DestinyInventoryItemDefinitionContext.Provider value={itemDefinitions}>
+        {itemDefinitions ? props.children : <p>loading...</p>}
+      </DestinyInventoryItemDefinitionContext.Provider>
+    </>
   );
 }
-
-export default DestinyInventoryItemDefinitionContext;

--- a/app/_context/DestinyInventoryItemDefinitionContext.tsx
+++ b/app/_context/DestinyInventoryItemDefinitionContext.tsx
@@ -1,12 +1,14 @@
-import { useState, useEffect, createContext, useContext } from 'react';
+import { useState, useEffect, createContext } from 'react';
 import { useManifestStatus } from '../_hooks/useManifestStatus';
 import { get } from 'idb-keyval';
+import { ItemTableType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 
-export const DestinyInventoryItemDefinitionContext = createContext();
+export const DestinyInventoryItemDefinitionContext =
+  createContext<ItemTableType>({});
 
 export function DestinyInventoryItemDefinitionContextProvider(props: any) {
   const manifestIsLoaded = useManifestStatus();
-  const [itemDefinitions, setItemDefinitions] = useState();
+  const [itemDefinitions, setItemDefinitions] = useState<ItemTableType>({});
 
   const getItemDefinitions = async () => {
     const manifest = await get('manifest');
@@ -16,7 +18,7 @@ export function DestinyInventoryItemDefinitionContextProvider(props: any) {
   useEffect(() => {
     if (!manifestIsLoaded) return;
     (async () => {
-      const itemDefinitions = await getItemDefinitions();
+      const itemDefinitions: ItemTableType = await getItemDefinitions();
       setItemDefinitions(itemDefinitions);
     })();
   }, [manifestIsLoaded]);

--- a/app/_context/DestinyInventoryItemDefinitionContext.tsx
+++ b/app/_context/DestinyInventoryItemDefinitionContext.tsx
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+
+const DestinyInventoryItemDefinitionContext = createContext();
+
+export function DestinyInventoryItemDefinitionContextProvider() {
+  return (
+    <DestinyInventoryItemDefinitionContext.Provider
+      value={'placeholder'}
+    ></DestinyInventoryItemDefinitionContext.Provider>
+  );
+}
+
+export default DestinyInventoryItemDefinitionContext;

--- a/app/_context/DestinyInventoryItemDefinitionContext.tsx
+++ b/app/_context/DestinyInventoryItemDefinitionContext.tsx
@@ -26,7 +26,7 @@ export function DestinyInventoryItemDefinitionContextProvider(props: any) {
   return (
     <>
       <DestinyInventoryItemDefinitionContext.Provider value={itemDefinitions}>
-        {itemDefinitions ? props.children : <p>loading...</p>}
+        {Object.keys(itemDefinitions).length > 0 ? props.children : <p>loading...</p>}
       </DestinyInventoryItemDefinitionContext.Provider>
     </>
   );

--- a/app/_interfaces/manifestTables/DestinyInventoryItemDefinition.interface.ts
+++ b/app/_interfaces/manifestTables/DestinyInventoryItemDefinition.interface.ts
@@ -1,8 +1,12 @@
-export default interface ItemType {
+export interface ItemType {
   displayProperties: {
     name: string;
     icon: string;
   };
   flavorText: string;
   itemTypeAndTierDisplayName: string;
+}
+
+export interface ItemTableType {
+  [key: number]: ItemType;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import SearchComponent from './_components/SearchResult';
 import { get } from 'idb-keyval';
 import { useManifestStatus } from './_hooks/useManifestStatus';
 import PlayerSearchResultType from './_interfaces/PlayerSearchResult.interface';
+import DestinyInventoryItemDefinitionContext from './_context/DestinyInventoryItemDefinitionContext';
 
 const URL = process.env.NEXT_PUBLIC_URL || 'http://localhost:3000';
 
@@ -126,23 +127,25 @@ export default function Home() {
 
   const loadedView = (
     <>
-      <div className="flex flex-col items-center mt-2 gap-1">
-        <input
-          value={username}
-          placeholder="search by Bungie name..."
-          className="bg-slate-900 border border-slate-500 w-60"
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        {/* need to rewrite this to show the user some kind of difference between an empty input and an input that returned no results from Bungie */}
-        {searchResultComponents.length ? searchResultsContainer : null}
-      </div>
-      {characterData && itemDefinitions && itemInstances ? (
-        <CharacterContainer
-          characterData={characterData}
-          itemDefinitions={itemDefinitions}
-          itemInstances={itemInstances}
-        />
-      ) : null}
+      <DestinyInventoryItemDefinitionContext.Provider value={itemDefinitions}>
+        <div className="flex flex-col items-center mt-2 gap-1">
+          <input
+            value={username}
+            placeholder="search by Bungie name..."
+            className="bg-slate-900 border border-slate-500 w-60"
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          {/* need to rewrite this to show the user some kind of difference between an empty input and an input that returned no results from Bungie */}
+          {searchResultComponents.length ? searchResultsContainer : null}
+        </div>
+        {characterData && itemDefinitions && itemInstances ? (
+          <CharacterContainer
+            characterData={characterData}
+            itemDefinitions={itemDefinitions}
+            itemInstances={itemInstances}
+          />
+        ) : null}
+      </DestinyInventoryItemDefinitionContext.Provider>
     </>
   );
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,10 +3,8 @@
 import { useState, useEffect } from 'react';
 import CharacterContainer from './_components/CharacterContainer';
 import SearchComponent from './_components/SearchResult';
-import { get } from 'idb-keyval';
-import { useManifestStatus } from './_hooks/useManifestStatus';
 import PlayerSearchResultType from './_interfaces/PlayerSearchResult.interface';
-import DestinyInventoryItemDefinitionContext from './_context/DestinyInventoryItemDefinitionContext';
+import { DestinyInventoryItemDefinitionContextProvider } from './_context/DestinyInventoryItemDefinitionContext';
 
 const URL = process.env.NEXT_PUBLIC_URL || 'http://localhost:3000';
 
@@ -24,22 +22,6 @@ export default function Home() {
     useState<string>();
   const [characterData, setCharacterData] = useState();
   const [itemInstances, setItemInstances] = useState();
-  const [itemDefinitions, setItemDefinitions] = useState();
-  const manifestIsLoaded = useManifestStatus();
-
-  const getItemDefinitions = async () => {
-    const manifest = await get('manifest');
-    return manifest.DestinyItemInventoryDefinition;
-  };
-
-  // sets the manifest table as our state
-  useEffect(() => {
-    if (!manifestIsLoaded) return;
-    (async () => {
-      const itemDefinitions = await getItemDefinitions();
-      setItemDefinitions(itemDefinitions);
-    })();
-  }, [manifestIsLoaded]);
 
   useEffect(() => {
     const fetchUsers = setTimeout(async () => {
@@ -124,10 +106,10 @@ export default function Home() {
       {searchResultComponents}
     </div>
   );
-
-  const loadedView = (
-    <>
-      <DestinyInventoryItemDefinitionContext.Provider value={itemDefinitions}>
+  
+  return (
+    <main className="flex min-h-screen flex-col items-center pt-24">
+      <DestinyInventoryItemDefinitionContextProvider>
         <div className="flex flex-col items-center mt-2 gap-1">
           <input
             value={username}
@@ -138,23 +120,13 @@ export default function Home() {
           {/* need to rewrite this to show the user some kind of difference between an empty input and an input that returned no results from Bungie */}
           {searchResultComponents.length ? searchResultsContainer : null}
         </div>
-        {characterData && itemDefinitions && itemInstances ? (
+        {characterData && itemInstances ? (
           <CharacterContainer
             characterData={characterData}
-            itemDefinitions={itemDefinitions}
             itemInstances={itemInstances}
           />
         ) : null}
-      </DestinyInventoryItemDefinitionContext.Provider>
-    </>
-  );
-
-  const loadingView = <p>loading...</p>;
-
-  return (
-    <main className="flex min-h-screen flex-col items-center pt-24">
-      {/* show "loading" view until item definition data is done being placed into state */}
-      {itemDefinitions ? loadedView : loadingView}
+      </DestinyInventoryItemDefinitionContextProvider>
     </main>
   );
 }


### PR DESCRIPTION
This PR implements useContext as the first step of a significant refactor to prevent prop drilling from getting out of hand as the app grows in complexity.  I'd like to continue moving top-level data and logic into different pieces of context, but need to pause and reconcile various pieces of unmerged work before pushing this further.