### PR TITLE
Refactor context

### DIFF
--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -8,8 +8,8 @@ type Props = {
 };
 
 export default function Item({ itemHash, powerLevel }: Props) {
-  const definitions = useContext(ManifestContext);
-  const item = definitions[itemHash];
+  const { DestinyInventoryItemDefinition } = useContext(ManifestContext);
+  const item = DestinyInventoryItemDefinition[itemHash];
 
   return (
     <div className="flex border border-pink-300">

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -1,5 +1,4 @@
-import { useContext } from 'react';
-import { ManifestContext } from '../_context/ManifestContext';
+import { useManifestContext } from '../_context/ManifestContext';
 import Image from 'next/image';
 
 type Props = {
@@ -8,7 +7,7 @@ type Props = {
 };
 
 export default function Item({ itemHash, powerLevel }: Props) {
-  const { DestinyInventoryItemDefinition } = useContext(ManifestContext);
+  const { DestinyInventoryItemDefinition } = useManifestContext();
   const item = DestinyInventoryItemDefinition[itemHash];
 
   return (

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -1,9 +1,6 @@
-'use client';
-
 import { useContext } from 'react';
+import { ManifestContext } from '../_context/ManifestContext';
 import Image from 'next/image';
-import { DestinyInventoryItemDefinitionContext } from '../_context/DestinyInventoryItemDefinitionContext';
-import { ItemTableType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 
 type Props = {
   itemHash: number;
@@ -11,26 +8,24 @@ type Props = {
 };
 
 export default function Item({ itemHash, powerLevel }: Props) {
-  const definitions: ItemTableType = useContext(
-    DestinyInventoryItemDefinitionContext
-  );
+  const definitions = useContext(ManifestContext);
+  const item = definitions[itemHash];
+
   return (
     <div className="flex border border-pink-300">
       <div className="relative">
         <Image
-          src={`https://bungie.net${definitions[itemHash].displayProperties.icon}`}
+          src={`https://bungie.net${item.displayProperties.icon}`}
           alt=""
           width={80}
           height={80}
           className="w-20"
         />
-
-        {/* some items don't have a content-source watermark (e.g. "generalist shell") -- ternary here ensures the item has an iconWatermark property before trying to fetch from the image src */}
-
-        {definitions[itemHash].iconWatermark ? (
+        {/* ternary below is a safeguard for items that don't have a content-source watermark (e.g. "generalist shell") */}
+        {item.iconWatermark ? (
           <div className="absolute top-0">
             <Image
-              src={`https://bungie.net${definitions[itemHash].iconWatermark}`}
+              src={`https://bungie.net${item.iconWatermark}`}
               alt=""
               width={80}
               height={80}
@@ -40,13 +35,9 @@ export default function Item({ itemHash, powerLevel }: Props) {
         ) : null}
       </div>
       <div className="grow text-right">
-        <p className="text-xl">
-          {definitions[itemHash].displayProperties.name}
-        </p>
+        <p className="text-xl">{item.displayProperties.name}</p>
         {powerLevel ? <p className="text-sm bold mt-2">{powerLevel}</p> : null}
-        <p className="text-sm italic mt-2">
-          {definitions[itemHash].itemTypeAndTierDisplayName}
-        </p>
+        <p className="text-sm italic mt-2">{item.itemTypeAndTierDisplayName}</p>
       </div>
     </div>
   );

--- a/app/_context/ManifestContext.tsx
+++ b/app/_context/ManifestContext.tsx
@@ -3,10 +3,9 @@ import { useManifestStatus } from '../_hooks/useManifestStatus';
 import { get } from 'idb-keyval';
 import { ItemTableType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 
-export const DestinyInventoryItemDefinitionContext =
-  createContext<ItemTableType>({});
+export const ManifestContext = createContext<ItemTableType>({});
 
-export function DestinyInventoryItemDefinitionContextProvider(props: any) {
+export function ManifestContextProvider(props: any) {
   const manifestIsLoaded = useManifestStatus();
   const [itemDefinitions, setItemDefinitions] = useState<ItemTableType>({});
 
@@ -25,9 +24,13 @@ export function DestinyInventoryItemDefinitionContextProvider(props: any) {
 
   return (
     <>
-      <DestinyInventoryItemDefinitionContext.Provider value={itemDefinitions}>
-        {Object.keys(itemDefinitions).length > 0 ? props.children : <p>loading...</p>}
-      </DestinyInventoryItemDefinitionContext.Provider>
+      <ManifestContext.Provider value={itemDefinitions}>
+        {Object.keys(itemDefinitions).length > 0 ? (
+          props.children
+        ) : (
+          <p>loading...</p>
+        )}
+      </ManifestContext.Provider>
     </>
   );
 }

--- a/app/_context/ManifestContext.tsx
+++ b/app/_context/ManifestContext.tsx
@@ -11,7 +11,7 @@ export function ManifestContextProvider(props: any) {
 
   const getItemDefinitions = async () => {
     const manifest = await get('manifest');
-    return manifest.DestinyItemInventoryDefinition;
+    return manifest.DestinyInventoryItemDefinition;
   };
 
   useEffect(() => {

--- a/app/_context/ManifestContext.tsx
+++ b/app/_context/ManifestContext.tsx
@@ -8,18 +8,18 @@ export const ManifestContext = createContext<ManifestType | undefined>(
 );
 
 export function ManifestContextProvider(props: any) {
-  const manifestIsLoaded = useManifestStatus();
+  const newestManifestInStorage = useManifestStatus();
   const [manifest, setManifest] = useState<ManifestType | undefined>();
   const [manifestIsReady, setManifestIsReady] = useState(false);
 
   useEffect(() => {
-    if (!manifestIsLoaded) return;
+    if (!newestManifestInStorage) return;
     (async () => {
       const manifest: ManifestType | undefined = await get('manifest');
       setManifest(manifest);
       setManifestIsReady(true);
     })();
-  }, [manifestIsLoaded]);
+  }, [newestManifestInStorage]);
 
   return (
     <ManifestContext.Provider value={manifest}>

--- a/app/_context/ManifestContext.tsx
+++ b/app/_context/ManifestContext.tsx
@@ -1,35 +1,25 @@
 import { useState, useEffect, createContext } from 'react';
 import { useManifestStatus } from '../_hooks/useManifestStatus';
 import { get } from 'idb-keyval';
-import { ItemTableType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 
-export const ManifestContext = createContext<ItemTableType>({});
+export const ManifestContext = createContext({});
 
 export function ManifestContextProvider(props: any) {
   const manifestIsLoaded = useManifestStatus();
-  const [itemDefinitions, setItemDefinitions] = useState<ItemTableType>({});
-
-  const getItemDefinitions = async () => {
-    const manifest = await get('manifest');
-    return manifest.DestinyInventoryItemDefinition;
-  };
+  const [manifest, setManifest] = useState({});
 
   useEffect(() => {
     if (!manifestIsLoaded) return;
     (async () => {
-      const itemDefinitions: ItemTableType = await getItemDefinitions();
-      setItemDefinitions(itemDefinitions);
+      const manifest = await get('manifest');
+      setManifest(manifest);
     })();
   }, [manifestIsLoaded]);
 
   return (
     <>
-      <ManifestContext.Provider value={itemDefinitions}>
-        {Object.keys(itemDefinitions).length > 0 ? (
-          props.children
-        ) : (
-          <p>loading...</p>
-        )}
+      <ManifestContext.Provider value={manifest}>
+        {Object.keys(manifest).length > 0 ? props.children : <p>loading...</p>}
       </ManifestContext.Provider>
     </>
   );

--- a/app/_context/ManifestContext.tsx
+++ b/app/_context/ManifestContext.tsx
@@ -1,26 +1,37 @@
-import { useState, useEffect, createContext } from 'react';
-import { useManifestStatus } from '../_hooks/useManifestStatus';
+import { useState, useEffect, createContext, useContext } from 'react';
 import { get } from 'idb-keyval';
+import { useManifestStatus } from '../_hooks/useManifestStatus';
+import ManifestType from '../_interfaces/Manifest.interface';
 
-export const ManifestContext = createContext({});
+export const ManifestContext = createContext<ManifestType | undefined>(
+  undefined
+);
 
 export function ManifestContextProvider(props: any) {
   const manifestIsLoaded = useManifestStatus();
-  const [manifest, setManifest] = useState({});
+  const [manifest, setManifest] = useState<ManifestType | undefined>();
+  const [manifestIsReady, setManifestIsReady] = useState(false);
 
   useEffect(() => {
     if (!manifestIsLoaded) return;
     (async () => {
-      const manifest = await get('manifest');
+      const manifest: ManifestType | undefined = await get('manifest');
       setManifest(manifest);
+      setManifestIsReady(true);
     })();
   }, [manifestIsLoaded]);
 
   return (
-    <>
-      <ManifestContext.Provider value={manifest}>
-        {Object.keys(manifest).length > 0 ? props.children : <p>loading...</p>}
-      </ManifestContext.Provider>
-    </>
+    <ManifestContext.Provider value={manifest}>
+      {manifestIsReady ? props.children : <p>loading...</p>}
+    </ManifestContext.Provider>
   );
+}
+
+export function useManifestContext() {
+  const manifest = useContext(ManifestContext);
+  if (!manifest) {
+    throw new Error('Context must be used within a Provider');
+  }
+  return manifest;
 }

--- a/app/_hooks/useManifestStatus.ts
+++ b/app/_hooks/useManifestStatus.ts
@@ -25,11 +25,11 @@ export function useManifestStatus() {
   // fetch current manifest from bungie and save it in store
   const fetchManifest = async () => {
     const response = await fetch(`https://www.bungie.net${manifestPath}`);
-    const data = await response.json();
-    console.log(data);
+    const { DestinyMilestoneDefinition, DestinyInventoryItemDefinition } =
+      await response.json();
     set('manifest', {
-      DestinyMilestoneDefinition: data.DestinyMilestoneDefinition,
-      DestinyItemInventoryDefinition: data.DestinyInventoryItemDefinition,
+      DestinyMilestoneDefinition,
+      DestinyInventoryItemDefinition,
     });
   };
 

--- a/app/_interfaces/Manifest.interface.ts
+++ b/app/_interfaces/Manifest.interface.ts
@@ -1,0 +1,5 @@
+import { ItemTableType } from './manifestTables/DestinyInventoryItemDefinition.interface';
+
+export default interface ManifestType {
+  DestinyInventoryItemDefinition: ItemTableType;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import CharacterContainer from './_components/CharacterContainer';
 import SearchComponent from './_components/SearchResult';
 import PlayerSearchResultType from './_interfaces/PlayerSearchResult.interface';
-import { DestinyInventoryItemDefinitionContextProvider } from './_context/DestinyInventoryItemDefinitionContext';
+import { ManifestContextProvider } from './_context/ManifestContext';
 
 const URL = process.env.NEXT_PUBLIC_URL || 'http://localhost:3000';
 
@@ -105,7 +105,7 @@ export default function Home() {
 
   return (
     <main className="flex min-h-screen flex-col items-center pt-24">
-      <DestinyInventoryItemDefinitionContextProvider>
+      <ManifestContextProvider>
         <div className="flex flex-col items-center mt-2 gap-1">
           <input
             value={username}
@@ -122,7 +122,7 @@ export default function Home() {
             itemInstances={itemInstances}
           />
         ) : null}
-      </DestinyInventoryItemDefinitionContextProvider>
+      </ManifestContextProvider>
     </main>
   );
 }


### PR DESCRIPTION
The primary objective of this PR is to make the last PR's implementation of context more extensible, since more than one table of the manifest will ultimately need to be available to various parts of the app.  With that in mind, our context has been refactored to provide the entire manifest, rather than just one of its tables.

Additionally, much of the code relating to the manifest across multiple parts of the app has been revised for readability.