### PR TITLE
Remove fake equipment

### DIFF
--- a/app/_components/Character.tsx
+++ b/app/_components/Character.tsx
@@ -1,4 +1,5 @@
 import Item from './Item';
+import MissingItem from './MissingItem';
 import { usePlayerContext } from '../_context/PlayerContext';
 
 export default function Character({ characterId }: { characterId: string }) {
@@ -21,6 +22,11 @@ export default function Character({ characterId }: { characterId: string }) {
       />
     );
   });
+
+  // character should contain 11 items: 3 weapons, 5 armor pieces, ghost, sparrow, ship
+  while (itemComponents.length < 11) {
+    itemComponents.push(<MissingItem />);
+  }
 
   return <div className="rounded-md bg-gray-900">{itemComponents}</div>;
 }

--- a/app/_components/MissingItem.tsx
+++ b/app/_components/MissingItem.tsx
@@ -1,7 +1,7 @@
 export default function MissingItem() {
   return (
-    <div className="flex bg-slate-700 h-20 m-2 rounded-md">
-      <p>missing item placeholder</p>
+    <div className="flex justify-center items-center bg-slate-800 h-20 m-2 rounded-md">
+      <p className="italic text-slate-400">sparrow or ship not equipped</p>
     </div>
   );
 }

--- a/app/_components/MissingItem.tsx
+++ b/app/_components/MissingItem.tsx
@@ -1,0 +1,7 @@
+export default function MissingItem() {
+  return (
+    <div className="flex bg-slate-700 h-20 m-2 rounded-md">
+      <p>missing item placeholder</p>
+    </div>
+  );
+}

--- a/app/_context/PlayerContext.tsx
+++ b/app/_context/PlayerContext.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, createContext, useContext } from 'react';
 import PlayerContextType from '../_interfaces/PlayerContext.interface';
 import { GetProfileResponseType } from '../_interfaces/BungieAPI/GetProfileResponse.interface';
+import CharacterEquipmentType from '../_interfaces/CharacterEquipment.interface';
 
 const PlayerContext = createContext<PlayerContextType | undefined>(undefined);
 
@@ -37,6 +38,19 @@ export function PlayerContextProvider({ currentUserData, children }: Props) {
     };
   };
 
+  // item.transferStatus 3 gets rid of each piece of 'equipment' that can't be transferred between characters: subclass, clan banner, emblem, emotes, and finishers.  ref https://bungie-net.github.io/multi/schema_Destiny-TransferStatuses.html#schema_Destiny-TransferStatuses
+  const sliceEquipment = (characterEquipment: {
+    [key: string]: CharacterEquipmentType;
+  }) => {
+    for (const character in characterEquipment) {
+      characterEquipment[character].items = characterEquipment[
+        character
+      ].items.filter((item) => {
+        return item.transferStatus !== 3;
+      });
+    }
+  };
+
   useEffect(() => {
     if (currentUserData.membershipId === '') {
       return;
@@ -44,7 +58,11 @@ export function PlayerContextProvider({ currentUserData, children }: Props) {
       (async () => {
         try {
           const { characterEquipment, itemInstances } = await fetchCharacters();
-          setFetchedPlayerData({ characterEquipment, itemInstances });
+          sliceEquipment(characterEquipment);
+          setFetchedPlayerData({
+            characterEquipment,
+            itemInstances,
+          });
         } catch (error) {
           console.log(error);
         }

--- a/app/_context/PlayerContext.tsx
+++ b/app/_context/PlayerContext.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, createContext, useContext } from 'react';
 import PlayerContextType from '../_interfaces/PlayerContext.interface';
+import { GetProfileResponseType } from '../_interfaces/BungieAPI/GetProfileResponse.interface';
 
 const PlayerContext = createContext<PlayerContextType | undefined>(undefined);
 
@@ -28,7 +29,8 @@ export function PlayerContextProvider({ currentUserData, children }: Props) {
         membershipId,
       }),
     });
-    const { characterEquipment, itemComponents } = await response.json();
+    const { characterEquipment, itemComponents }: GetProfileResponseType =
+      await response.json();
     return {
       characterEquipment: characterEquipment.data,
       itemInstances: itemComponents.instances.data,

--- a/app/_interfaces/BungieAPI/GetProfileResponse.interface.ts
+++ b/app/_interfaces/BungieAPI/GetProfileResponse.interface.ts
@@ -1,0 +1,25 @@
+import CharacterDataType from '../CharacterData.interface';
+import CharacterEquipmentType from '../CharacterEquipment.interface';
+import ItemInstanceType from '../InventoryItemInstance.interface';
+
+export default interface GetProfileResponseType {
+  Response: {
+    characters?: {
+      data: {
+        [key: string]: CharacterDataType;
+      };
+    };
+    characterEquipment?: {
+      data: {
+        [key: string]: CharacterEquipmentType;
+      };
+    };
+    itemComponents?: {
+      instances: {
+        data: {
+          [key: string]: ItemInstanceType;
+        };
+      };
+    };
+  };
+}

--- a/app/_interfaces/BungieAPI/GetProfileResponse.interface.ts
+++ b/app/_interfaces/BungieAPI/GetProfileResponse.interface.ts
@@ -2,23 +2,25 @@ import CharacterDataType from '../CharacterData.interface';
 import CharacterEquipmentType from '../CharacterEquipment.interface';
 import ItemInstanceType from '../InventoryItemInstance.interface';
 
-export default interface GetProfileResponseType {
-  Response: {
-    characters?: {
-      data: {
-        [key: string]: CharacterDataType;
-      };
+export interface GetProfileType {
+  Response: GetProfileResponseType;
+}
+
+export interface GetProfileResponseType {
+  characters?: {
+    data: {
+      [key: string]: CharacterDataType;
     };
-    characterEquipment?: {
-      data: {
-        [key: string]: CharacterEquipmentType;
-      };
+  };
+  characterEquipment: {
+    data: {
+      [key: string]: CharacterEquipmentType;
     };
-    itemComponents?: {
-      instances: {
-        data: {
-          [key: string]: ItemInstanceType;
-        };
+  };
+  itemComponents: {
+    instances: {
+      data: {
+        [key: string]: ItemInstanceType;
       };
     };
   };

--- a/app/_interfaces/CharacterEquipment.interface.ts
+++ b/app/_interfaces/CharacterEquipment.interface.ts
@@ -1,19 +1,17 @@
 export default interface CharacterEquipmentType {
-  items: [
-    {
-      itemHash: number;
-      itemInstanceId: string;
-      quantity: number;
-      bindStatus: number;
-      location: number;
-      bucketHash: number;
-      transferStatus: number;
-      lockable: boolean;
-      state: number;
-      dismantlePermission: number;
-      isWrapper: boolean;
-      tooltipNotificationIndexes: [];
-      versionNumber?: number;
-    }
-  ];
+  items: {
+    itemHash: number;
+    itemInstanceId: string;
+    quantity: number;
+    bindStatus: number;
+    location: number;
+    bucketHash: number;
+    transferStatus: number;
+    lockable: boolean;
+    state: number;
+    dismantlePermission: number;
+    isWrapper: boolean;
+    tooltipNotificationIndexes: [];
+    versionNumber?: number;
+  }[];
 }

--- a/app/_interfaces/InventoryItemInstance.interface.ts
+++ b/app/_interfaces/InventoryItemInstance.interface.ts
@@ -1,7 +1,7 @@
 export default interface ItemInstanceType {
   damageType: number;
   damageTypeHash?: number;
-  primaryStat: {
+  primaryStat?: {
     statHash: number;
     value: number;
   };

--- a/app/api/get-bungie-profile/route.ts
+++ b/app/api/get-bungie-profile/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import GetProfileResponseType from '@/app/_interfaces/BungieAPI/GetProfileResponse.interface';
+import { GetProfileType } from '@/app/_interfaces/BungieAPI/GetProfileResponse.interface';
 
 export async function POST(request: NextRequest) {
   const fetchProfileInfo = async () => {
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
         },
       }
     );
-    const data: GetProfileResponseType = await response.json();
+    const data: GetProfileType = await response.json();
     return data.Response;
   };
 

--- a/app/api/get-bungie-profile/route.ts
+++ b/app/api/get-bungie-profile/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import GetProfileResponseType from '@/app/_interfaces/BungieAPI/GetProfileResponse.interface';
 
 export async function POST(request: NextRequest) {
   const fetchProfileInfo = async () => {
@@ -14,7 +15,7 @@ export async function POST(request: NextRequest) {
         },
       }
     );
-    const data = await response.json();
+    const data: GetProfileResponseType = await response.json();
     return data.Response;
   };
 


### PR DESCRIPTION
The objective of this PR is to reduce shown equipment to what intuitively counts as 'equipment' (i.e., no 'finishers' item or seasonal artifact).  This PR filters out items that can't be transferred between characters, and adds a dummy item as a placeholder for characters who don't have a sparrow or ship equipped (look up Jake #158 for an example of this).