### PR TITLE
Sort search results

### DIFF
--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -35,6 +35,7 @@ export default function Item({ itemHash, itemInstance }: Props) {
     <div className="flex bg-slate-700 max-h-20 m-2 rounded-md">
       <div className="relative border-r-2 border-gray-900">
         <Image
+          unoptimized
           src={`https://bungie.net${item.displayProperties.icon}`}
           alt=""
           width={64}
@@ -45,6 +46,7 @@ export default function Item({ itemHash, itemInstance }: Props) {
         {item.iconWatermark ? (
           <div className="absolute top-0">
             <Image
+              unoptimized
               src={`https://bungie.net${item.iconWatermark}`}
               alt=""
               width={64}
@@ -59,6 +61,7 @@ export default function Item({ itemHash, itemInstance }: Props) {
           <p>{item.displayProperties.name}</p>
           {damageType ? (
             <Image
+              unoptimized
               src={`https://bungie.net${damageType.displayProperties.icon}`}
               alt=""
               width={20}
@@ -73,6 +76,7 @@ export default function Item({ itemHash, itemInstance }: Props) {
           ) : null}
           {powerLevel ? (
             <Image
+              unoptimized
               src={`https://bungie.net${powerIconPath}`}
               alt=""
               width={20}

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -58,7 +58,7 @@ export default function Item({ itemHash, itemInstance }: Props) {
       </div>
       <div className="w-60 p-2 flex flex-col justify-between">
         <div className="flex gap-1 justify-end">
-          <p>{item.displayProperties.name}</p>
+          <p className="text-sm">{item.displayProperties.name}</p>
           {damageType ? (
             <Image
               unoptimized

--- a/app/_components/SearchResult.tsx
+++ b/app/_components/SearchResult.tsx
@@ -29,6 +29,7 @@ export default function SearchResult({ profileData, handleUserClick }: Props) {
         </p>
       </div>
       <Image
+        unoptimized
         src={`https://bungie.net${
           characters[characterIds[0]].emblemBackgroundPath
         }`}

--- a/app/_components/SearchResultContainer.tsx
+++ b/app/_components/SearchResultContainer.tsx
@@ -20,6 +20,14 @@ export default function SearchResultContainer({
     setCurrentUserData({ membershipId, membershipType });
     setSearchResults([]);
   };
+
+  // following sort operation is likely hard to follow due to the complicated shape of the data.  searchResult.characters.data is an object whose keys are strings containing characterIds.  We want to access data from the "first" characterId (as this is the information we're digging into in each SearchResult component).  Since that key is a different value in each searchResult, the most straightforward way to access it systematically is invoking Object.keys() here as well.  The stat we're sorting by at the end of the expression is the character's power level.
+  searchResults.sort(
+    (a, b) =>
+      b.characters.data[Object.keys(b.characters.data)[0]].stats[1935470627] -
+      a.characters.data[Object.keys(a.characters.data)[0]].stats[1935470627]
+  );
+
   const searchResultComponents = searchResults.map((searchResult, i) => {
     return (
       <SearchResult

--- a/app/_components/SearchResultContainer.tsx
+++ b/app/_components/SearchResultContainer.tsx
@@ -1,0 +1,33 @@
+import SearchResult from './SearchResult';
+import { GetBasicProfileResponseType } from '../_interfaces/BungieAPI/GetBasicProfileResponse.interface';
+
+type Props = {
+  searchResults: GetBasicProfileResponseType[];
+  setSearchResults: React.Dispatch<
+    React.SetStateAction<GetBasicProfileResponseType[]>
+  >;
+  setCurrentUserData: React.Dispatch<
+    React.SetStateAction<{ membershipId: string; membershipType: number }>
+  >;
+};
+
+export default function SearchResultContainer({
+  searchResults,
+  setSearchResults,
+  setCurrentUserData,
+}: Props) {
+  const handleUserClick = (membershipId: string, membershipType: number) => {
+    setCurrentUserData({ membershipId, membershipType });
+    setSearchResults([]);
+  };
+  const searchResultComponents = searchResults.map((searchResult, i) => {
+    return (
+      <SearchResult
+        profileData={searchResult}
+        handleUserClick={handleUserClick}
+        key={`search result ${i}`}
+      />
+    );
+  });
+  return <>{searchResultComponents}</>;
+}

--- a/app/_context/PlayerContext.tsx
+++ b/app/_context/PlayerContext.tsx
@@ -53,6 +53,10 @@ export function PlayerContextProvider({ currentUserData, children }: Props) {
 
   useEffect(() => {
     if (currentUserData.membershipId === '') {
+      setFetchedPlayerData({
+        characterEquipment: {},
+        itemInstances: {},
+      });
       return;
     } else {
       (async () => {

--- a/app/_context/PlayerContext.tsx
+++ b/app/_context/PlayerContext.tsx
@@ -38,8 +38,8 @@ export function PlayerContextProvider({ currentUserData, children }: Props) {
     };
   };
 
-  // item.transferStatus 3 gets rid of each piece of 'equipment' that can't be transferred between characters: subclass, clan banner, emblem, emotes, and finishers.  ref https://bungie-net.github.io/multi/schema_Destiny-TransferStatuses.html#schema_Destiny-TransferStatuses
-  const sliceEquipment = (characterEquipment: {
+  // item.transferStatus 3 gets rid of each piece of 'equipment' that can't be transferred between characters: subclass, clan banner, emblem, emotes, and finishers.  ref https://bungie-net.github.io/multi/schema_Destiny-TransferStatuses.html
+  const filterEquipment = (characterEquipment: {
     [key: string]: CharacterEquipmentType;
   }) => {
     for (const character in characterEquipment) {
@@ -58,7 +58,7 @@ export function PlayerContextProvider({ currentUserData, children }: Props) {
       (async () => {
         try {
           const { characterEquipment, itemInstances } = await fetchCharacters();
-          sliceEquipment(characterEquipment);
+          filterEquipment(characterEquipment);
           setFetchedPlayerData({
             characterEquipment,
             itemInstances,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import Nav from './_components/Nav';
 import CharacterContainer from './_components/CharacterContainer';
-import SearchResult from './_components/SearchResult';
+import SearchResultContainer from './_components/SearchResultContainer';
 import useGenerateSearchResults from './_hooks/useGenerateSearchResults';
 import { GetBasicProfileResponseType } from './_interfaces/BungieAPI/GetBasicProfileResponse.interface';
 import { ManifestContextProvider } from './_context/ManifestContext';
@@ -13,9 +13,6 @@ export default function Home() {
   const [username, setUsername] = useState('');
   const [searchResults, setSearchResults] = useState<
     GetBasicProfileResponseType[]
-  >([]);
-  const [searchResultComponents, setSearchResultComponents] = useState<
-    JSX.Element[]
   >([]);
   const [currentUserData, setCurrentUserData] = useState({
     membershipId: '',
@@ -34,38 +31,17 @@ export default function Home() {
     setCurrentUserData({ membershipId: '', membershipType: 0 });
   }, [username]);
 
-  useEffect(() => {
-    if (searchResults.length === 0) {
-      setSearchResultComponents([]);
-      return;
-    }
-
-    const handleUserClick = (membershipId: string, membershipType: number) => {
-      setCurrentUserData({ membershipId, membershipType });
-      setSearchResultComponents([]);
-    };
-
-    const searchResultComponents = searchResults.map((searchResult, i) => {
-      return (
-        <SearchResult
-          profileData={searchResult}
-          handleUserClick={handleUserClick}
-          key={`search result ${i}`}
-        />
-      );
-    });
-    setSearchResultComponents(searchResultComponents);
-  }, [searchResults]);
-
-  const searchResultsContainer = <>{searchResultComponents}</>;
-
   return (
     <>
       <ManifestContextProvider>
         <Nav setUsername={setUsername} />
         <main className="flex min-h-screen flex-col items-center pt-24">
           <PlayerContextProvider currentUserData={currentUserData}>
-            {searchResultsContainer}
+            <SearchResultContainer
+              searchResults={searchResults}
+              setSearchResults={setSearchResults}
+              setCurrentUserData={setCurrentUserData}
+            />
             {currentUserData.membershipId === '' ? null : (
               <CharacterContainer />
             )}


### PR DESCRIPTION
The main objective of this PR is to mitigate against one of the app's most glaring issues: search result relevance.  For queries that return ~10 or fewer results, this is not too big an issue.  However, the more generic a username, the more likely it is that a user will have a hard time finding their profile, especially in the case that there are more than 25 results (since the app will only retrieve the first page of username results from Bungie).

Search result relevance is going to be complicated to fix overall, but for now we can at least show the highest power levels first and relegate the 1600-power "dead profiles" to the bottom of the list.