### PR TITLE
Improve missing items

### DIFF
--- a/app/_components/Character.tsx
+++ b/app/_components/Character.tsx
@@ -7,21 +7,20 @@ export default function Character({ characterId }: { characterId: string }) {
   const { characterEquipment, itemInstances } = usePlayerContext();
   const { DestinyInventoryItemDefinition } = useManifestContext();
 
-  const ids: {
-    [key: number]: boolean;
-  } = {
-    1498876634: false, // primary weapon
-    2465295065: false, // energy weapon
-    953998645: false, // heavy weapon
-    3448274439: false, // helmet
-    3551918588: false, // chest
-    14239492: false, // gloves
-    20886954: false, // legs
-    1585787867: false, // class item
-    4023194814: false, // ghost
-    2025709351: false, // sparrow
-    284967655: false, // ship
-  };
+  const itemSlots: [number, boolean, string][] = [
+    // the tuples in this array are composed of an equipmentSlotTypeHash, a boolean representing the presence of an item in that slot in the current user's inventory, and a string identifying the name of the item slot.  note that order is important here: this array is ordered to match the order in which Bungie's API returns equipped item results
+    [1498876634, false, 'primary weapon'],
+    [2465295065, false, 'energy weapon'],
+    [953998645, false, 'heavy weapon'],
+    [3448274439, false, 'helmet armor'],
+    [3551918588, false, 'chest armor'],
+    [14239492, false, 'gloves'],
+    [20886954, false, 'leg armor'],
+    [1585787867, false, 'class item'],
+    [4023194814, false, 'ghost'],
+    [2025709351, false, 'sparrow'],
+    [284967655, false, 'ship'],
+  ];
 
   const itemHashes = characterEquipment[characterId].items.map((item) => {
     return item.itemHash;
@@ -33,9 +32,15 @@ export default function Character({ characterId }: { characterId: string }) {
 
   const itemComponents = itemHashes.map((itemHash, i) => {
     const item = DestinyInventoryItemDefinition[itemHash];
-    item.equippingBlock
-      ? (ids[item.equippingBlock.equipmentSlotTypeHash] = true)
-      : null;
+
+    if (item.equippingBlock) {
+      itemSlots.forEach((itemSlot) => {
+        if (itemSlot[0] === item.equippingBlock?.equipmentSlotTypeHash) {
+          itemSlot[1] = true;
+        }
+      });
+    }
+
     return (
       <Item
         itemInstance={itemInstances[itemInstanceIds[i]]}
@@ -45,12 +50,15 @@ export default function Character({ characterId }: { characterId: string }) {
     );
   });
 
-  console.log(ids);
-
-  // character should contain 11 items: 3 weapons, 5 armor pieces, ghost, sparrow, ship
-  while (itemComponents.length < 11) {
-    itemComponents.push(<MissingItem key={itemComponents.length} />);
-  }
+  itemSlots.forEach((itemSlot, i) => {
+    if (itemSlot[1] === false) {
+      itemComponents.splice(
+        i,
+        0,
+        <MissingItem itemSlot={itemSlot[2]} key={i} />
+      );
+    }
+  });
 
   return <div className="rounded-md bg-gray-900">{itemComponents}</div>;
 }

--- a/app/_components/Character.tsx
+++ b/app/_components/Character.tsx
@@ -7,6 +7,22 @@ export default function Character({ characterId }: { characterId: string }) {
   const { characterEquipment, itemInstances } = usePlayerContext();
   const { DestinyInventoryItemDefinition } = useManifestContext();
 
+  const ids: {
+    [key: number]: boolean;
+  } = {
+    1498876634: false, // primary weapon
+    2465295065: false, // energy weapon
+    953998645: false, // heavy weapon
+    3448274439: false, // helmet
+    3551918588: false, // chest
+    14239492: false, // gloves
+    20886954: false, // legs
+    1585787867: false, // class item
+    4023194814: false, // ghost
+    2025709351: false, // sparrow
+    284967655: false, // ship
+  };
+
   const itemHashes = characterEquipment[characterId].items.map((item) => {
     return item.itemHash;
   });
@@ -17,6 +33,9 @@ export default function Character({ characterId }: { characterId: string }) {
 
   const itemComponents = itemHashes.map((itemHash, i) => {
     const item = DestinyInventoryItemDefinition[itemHash];
+    item.equippingBlock
+      ? (ids[item.equippingBlock.equipmentSlotTypeHash] = true)
+      : null;
     return (
       <Item
         itemInstance={itemInstances[itemInstanceIds[i]]}
@@ -25,6 +44,8 @@ export default function Character({ characterId }: { characterId: string }) {
       />
     );
   });
+
+  console.log(ids);
 
   // character should contain 11 items: 3 weapons, 5 armor pieces, ghost, sparrow, ship
   while (itemComponents.length < 11) {

--- a/app/_components/Character.tsx
+++ b/app/_components/Character.tsx
@@ -1,9 +1,11 @@
 import Item from './Item';
 import MissingItem from './MissingItem';
 import { usePlayerContext } from '../_context/PlayerContext';
+import { useManifestContext } from '../_context/ManifestContext';
 
 export default function Character({ characterId }: { characterId: string }) {
   const { characterEquipment, itemInstances } = usePlayerContext();
+  const { DestinyInventoryItemDefinition } = useManifestContext();
 
   const itemHashes = characterEquipment[characterId].items.map((item) => {
     return item.itemHash;
@@ -14,10 +16,11 @@ export default function Character({ characterId }: { characterId: string }) {
   });
 
   const itemComponents = itemHashes.map((itemHash, i) => {
+    const item = DestinyInventoryItemDefinition[itemHash];
     return (
       <Item
-        itemHash={itemHash}
         itemInstance={itemInstances[itemInstanceIds[i]]}
+        item={item}
         key={i}
       />
     );

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -2,20 +2,17 @@ import { useManifestContext } from '../_context/ManifestContext';
 import Image from 'next/image';
 import ItemInstanceType from '../_interfaces/InventoryItemInstance.interface';
 import { DamageType } from '../_interfaces/manifestTables/DestinyDamageTypeDefinition.interface';
+import { ItemType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 
 type Props = {
-  itemHash: number;
   itemInstance: ItemInstanceType;
+  item: ItemType;
 };
 
-export default function Item({ itemHash, itemInstance }: Props) {
-  const {
-    DestinyDamageTypeDefinition,
-    DestinyInventoryItemDefinition,
-    DestinyStatDefinition,
-  } = useManifestContext();
+export default function Item({ itemInstance, item }: Props) {
+  const { DestinyDamageTypeDefinition, DestinyStatDefinition } =
+    useManifestContext();
 
-  const item = DestinyInventoryItemDefinition[itemHash];
   let damageType: DamageType | undefined = undefined;
   if (itemInstance.damageTypeHash) {
     damageType = DestinyDamageTypeDefinition[itemInstance.damageTypeHash];
@@ -30,8 +27,6 @@ export default function Item({ itemHash, itemInstance }: Props) {
     // hash below is for the "power" stat so we can get a link to its icon, the path of which seems to be variable over time.  reluctant to lean too heavily on a hardcoded value here, but it *looks* like manifest entities don't have their hashes change, at least not commonly.  probably worth revisiting this to see if there's a more systematic way to source the icon URL
     powerIconPath = DestinyStatDefinition[1935470627].displayProperties.icon;
   }
-
-  console.log(item.equippingBlock?.equipmentSlotTypeHash);
 
   return (
     <div className="flex bg-slate-700 max-h-20 m-2 rounded-md">

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -31,6 +31,8 @@ export default function Item({ itemHash, itemInstance }: Props) {
     powerIconPath = DestinyStatDefinition[1935470627].displayProperties.icon;
   }
 
+  console.log(item.equippingBlock?.equipmentSlotTypeHash);
+
   return (
     <div className="flex bg-slate-700 max-h-20 m-2 rounded-md">
       <div className="relative border-r-2 border-gray-900">

--- a/app/_components/MissingItem.tsx
+++ b/app/_components/MissingItem.tsx
@@ -1,7 +1,7 @@
-export default function MissingItem() {
+export default function MissingItem({ itemSlot }: { itemSlot: string }) {
   return (
     <div className="flex justify-center items-center bg-slate-800 h-16 m-2 rounded-md">
-      <p className="italic text-slate-400">sparrow or ship not equipped</p>
+      <p className="italic text-slate-400"> {itemSlot} not equipped</p>
     </div>
   );
 }

--- a/app/_interfaces/manifestTables/DestinyInventoryItemDefinition.interface.ts
+++ b/app/_interfaces/manifestTables/DestinyInventoryItemDefinition.interface.ts
@@ -3,6 +3,9 @@ export interface ItemType {
     name: string;
     icon: string;
   };
+  equippingBlock?: {
+    equipmentSlotTypeHash: string;
+  };
   flavorText: string;
   iconWatermark?: string;
   itemTypeAndTierDisplayName: string;

--- a/app/_interfaces/manifestTables/DestinyInventoryItemDefinition.interface.ts
+++ b/app/_interfaces/manifestTables/DestinyInventoryItemDefinition.interface.ts
@@ -4,7 +4,7 @@ export interface ItemType {
     icon: string;
   };
   equippingBlock?: {
-    equipmentSlotTypeHash: string;
+    equipmentSlotTypeHash: number;
   };
   flavorText: string;
   iconWatermark?: string;


### PR DESCRIPTION
This PR solves #30.  By moving robust item info lookup from the `item` component up a level to `character`, we can examine each of a character's items to see which item slot they belong to, assess which slots are missing, and insert more specific placeholders into those missing slots.