### PR TITLE
Item perks

### DIFF
--- a/app/_components/Character.tsx
+++ b/app/_components/Character.tsx
@@ -4,7 +4,7 @@ import { usePlayerContext } from '../_context/PlayerContext';
 import { useManifestContext } from '../_context/ManifestContext';
 
 export default function Character({ characterId }: { characterId: string }) {
-  const { characterEquipment, itemInstances } = usePlayerContext();
+  const { characterEquipment, itemInstances, itemPerks } = usePlayerContext();
   const { DestinyInventoryItemDefinition } = useManifestContext();
 
   const itemSlots: [number, boolean, string][] = [
@@ -44,6 +44,7 @@ export default function Character({ characterId }: { characterId: string }) {
     return (
       <Item
         itemInstance={itemInstances[itemInstanceIds[i]]}
+        itemPerks={itemPerks[itemInstanceIds[i]]}
         item={item}
         key={`item ${i}`}
       />

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import ItemPerk from './ItemPerk';
 import { useManifestContext } from '../_context/ManifestContext';
 import ItemInstanceType from '../_interfaces/InventoryItemInstance.interface';
 import ItemPerkType from '../_interfaces/ItemPerk.interface';
@@ -16,7 +17,17 @@ export default function Item({ itemInstance, itemPerks, item }: Props) {
   const { DestinyDamageTypeDefinition, DestinyStatDefinition } =
     useManifestContext();
 
-  console.log(item.displayProperties.name, itemPerks);
+  console.log(item.displayProperties.name, itemPerks, itemInstance);
+
+  let itemPerkComponents: any;
+
+  if (itemPerks) {
+    itemPerkComponents = itemPerks.perks.map(
+      (itemPerk: ItemPerkType, i: number) => {
+        return <ItemPerk key={`itemPerk ${i}`} />;
+      }
+    );
+  }
 
   let damageType: DamageType | undefined = undefined;
   if (itemInstance.damageTypeHash) {
@@ -72,7 +83,8 @@ export default function Item({ itemInstance, itemPerks, item }: Props) {
             />
           ) : null}
         </div>
-        <div className="flex gap-0.5 justify-end">
+        <div className="flex gap-0.5 items-center justify-end">
+          {itemPerkComponents}
           {powerLevel ? (
             <p className="text-sm font-semibold">{powerLevel}</p>
           ) : null}

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -74,7 +74,7 @@ export default function Item({ itemInstance, itemPerks, item }: Props) {
           ) : null}
         </div>
       </div>
-      <div className="w-60 p-2 flex flex-col justify-between">
+      <div className="w-60 p-1 flex flex-col justify-around items-end">
         <div className="flex gap-1 justify-end">
           <p className="text-sm truncate">{item.displayProperties.name}</p>
           {damageType ? (
@@ -88,9 +88,11 @@ export default function Item({ itemInstance, itemPerks, item }: Props) {
             />
           ) : null}
         </div>
-        <div className="flex gap-0.5 items-center justify-end">
-          {itemPerkComponents}
-        </div>
+        {itemPerkComponents.length > 0 ? (
+          <div className="p-0.5 w-fit rounded-md flex gap-0.5 items-center justify-end bg-slate-800 shadow-black shadow-inner">
+            {itemPerkComponents}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -66,6 +66,13 @@ export default function Item({ itemInstance, itemPerks, item }: Props) {
             />
           </div>
         ) : null}
+        <div className="absolute bottom-0 right-0 w-full text-power-level drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)] bg-gradient-to-l from-slate-500/25">
+          {powerLevel ? (
+            <p className="text-sm text-end font-semibold pr-0.5">
+              {powerLevel}
+            </p>
+          ) : null}
+        </div>
       </div>
       <div className="w-60 p-2 flex flex-col justify-between">
         <div className="flex gap-1 justify-end">
@@ -83,18 +90,6 @@ export default function Item({ itemInstance, itemPerks, item }: Props) {
         </div>
         <div className="flex gap-0.5 items-center justify-end">
           {itemPerkComponents}
-          {powerLevel ? (
-            <p className="text-sm font-semibold">{powerLevel}</p>
-          ) : null}
-          {powerLevel ? (
-            <Image
-              unoptimized
-              src={`https://bungie.net${powerIconPath}`}
-              alt=""
-              width={20}
-              height={20}
-            />
-          ) : null}
         </div>
       </div>
     </div>

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -17,14 +17,12 @@ export default function Item({ itemInstance, itemPerks, item }: Props) {
   const { DestinyDamageTypeDefinition, DestinyStatDefinition } =
     useManifestContext();
 
-  console.log(item.displayProperties.name, itemPerks, itemInstance);
-
-  let itemPerkComponents: any;
+  let itemPerkComponents: JSX.Element[] = [];
 
   if (itemPerks) {
     itemPerkComponents = itemPerks.perks.map(
       (itemPerk: ItemPerkType, i: number) => {
-        return <ItemPerk key={`itemPerk ${i}`} />;
+        return <ItemPerk itemPerk={itemPerk} key={`itemPerk ${i}`} />;
       }
     );
   }

--- a/app/_components/Item.tsx
+++ b/app/_components/Item.tsx
@@ -1,17 +1,22 @@
-import { useManifestContext } from '../_context/ManifestContext';
 import Image from 'next/image';
+import { useManifestContext } from '../_context/ManifestContext';
 import ItemInstanceType from '../_interfaces/InventoryItemInstance.interface';
+import ItemPerkType from '../_interfaces/ItemPerk.interface';
 import { DamageType } from '../_interfaces/manifestTables/DestinyDamageTypeDefinition.interface';
 import { ItemType } from '../_interfaces/manifestTables/DestinyInventoryItemDefinition.interface';
 
 type Props = {
   itemInstance: ItemInstanceType;
+  // ships have no perks, so itemPerks will necessarily be undefined for one item per character.  would like to come back to this and refactor in a way that can distinguish between this and unintentionally undefined results
+  itemPerks: { perks: ItemPerkType[] } | undefined;
   item: ItemType;
 };
 
-export default function Item({ itemInstance, item }: Props) {
+export default function Item({ itemInstance, itemPerks, item }: Props) {
   const { DestinyDamageTypeDefinition, DestinyStatDefinition } =
     useManifestContext();
+
+  console.log(item.displayProperties.name, itemPerks);
 
   let damageType: DamageType | undefined = undefined;
   if (itemInstance.damageTypeHash) {

--- a/app/_components/ItemPerk.tsx
+++ b/app/_components/ItemPerk.tsx
@@ -1,3 +1,26 @@
-export default function ItemPerk() {
-  return <p className="bg-slate-400">ph</p>;
+import ItemPerkType from '../_interfaces/ItemPerk.interface';
+import { useManifestContext } from '../_context/ManifestContext';
+import Image from 'next/image';
+
+export default function ItemPerk({ itemPerk }: { itemPerk: ItemPerkType }) {
+  const { DestinySandboxPerkDefinition } = useManifestContext();
+  if (itemPerk.visible) {
+    console.log(DestinySandboxPerkDefinition[itemPerk.perkHash]);
+  }
+
+  return (
+    <div>
+      {itemPerk.visible ? (
+        <div>
+          <Image
+            unoptimized
+            src={`https://bungie.net${itemPerk.iconPath}`}
+            alt=""
+            width={24}
+            height={24}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/app/_components/ItemPerk.tsx
+++ b/app/_components/ItemPerk.tsx
@@ -1,0 +1,3 @@
+export default function ItemPerk() {
+  return <p className="bg-slate-400">ph</p>;
+}

--- a/app/_components/ItemPerk.tsx
+++ b/app/_components/ItemPerk.tsx
@@ -4,23 +4,20 @@ import Image from 'next/image';
 
 export default function ItemPerk({ itemPerk }: { itemPerk: ItemPerkType }) {
   const { DestinySandboxPerkDefinition } = useManifestContext();
-  if (itemPerk.visible) {
-    console.log(DestinySandboxPerkDefinition[itemPerk.perkHash]);
+
+  if (!itemPerk.visible) {
+    return null;
   }
 
+  console.log(DestinySandboxPerkDefinition[itemPerk.perkHash]);
+
   return (
-    <div>
-      {itemPerk.visible ? (
-        <div>
-          <Image
-            unoptimized
-            src={`https://bungie.net${itemPerk.iconPath}`}
-            alt=""
-            width={24}
-            height={24}
-          />
-        </div>
-      ) : null}
-    </div>
+    <Image
+      unoptimized
+      src={`https://bungie.net${itemPerk.iconPath}`}
+      alt=""
+      width={24}
+      height={24}
+    />
   );
 }

--- a/app/_components/ItemPerk.tsx
+++ b/app/_components/ItemPerk.tsx
@@ -9,7 +9,9 @@ export default function ItemPerk({ itemPerk }: { itemPerk: ItemPerkType }) {
     return null;
   }
 
-  console.log(DestinySandboxPerkDefinition[itemPerk.perkHash]);
+  const perkDefinition = DestinySandboxPerkDefinition[itemPerk.perkHash];
+
+  // notes for future: (a) eventually, would like to create a tooltip on hovering the perk that provides the user with some of the information available via perkDefinition.  (b) it seems like some of the perk images provided by bungie's API (specifically most of the armor perks) are not fully transparent, leading to a noticeable background square around the outside of the actual icon.  tried getting rid of this a bunch of different ways and ultimately decided to ship for now and revisit later.  might be worth reaching out to a dev of a different app like DIM to try to learn whether other folks have run into this and how they've solved it.
 
   return (
     <Image

--- a/app/_context/PlayerContext.tsx
+++ b/app/_context/PlayerContext.tsx
@@ -23,6 +23,7 @@ export function PlayerContextProvider({
     {
       characterEquipment: {},
       itemInstances: {},
+      itemPerks: {},
     }
   );
 
@@ -42,6 +43,7 @@ export function PlayerContextProvider({
     return {
       characterEquipment: characterEquipment.data,
       itemInstances: itemComponents.instances.data,
+      itemPerks: itemComponents.perks.data,
     };
   };
 
@@ -63,16 +65,18 @@ export function PlayerContextProvider({
       setFetchedPlayerData({
         characterEquipment: {},
         itemInstances: {},
+        itemPerks: {},
       });
       return;
     } else {
       (async () => {
         try {
-          const { characterEquipment, itemInstances } = await fetchCharacters();
+          const { characterEquipment, itemInstances, itemPerks } = await fetchCharacters();
           filterEquipment(characterEquipment);
           setFetchedPlayerData({
             characterEquipment,
             itemInstances,
+            itemPerks
           });
         } catch (error) {
           console.log(error);

--- a/app/_hooks/useManifestStatus.ts
+++ b/app/_hooks/useManifestStatus.ts
@@ -59,12 +59,14 @@ export function useManifestStatus() {
     const {
       DestinyDamageTypeDefinition,
       DestinyInventoryItemDefinition,
+      DestinySandboxPerkDefinition,
       DestinyStatDefinition,
     } = await response.json();
 
     set('manifest', {
       DestinyDamageTypeDefinition,
       DestinyInventoryItemDefinition,
+      DestinySandboxPerkDefinition,
       DestinyStatDefinition,
     });
   };
@@ -72,6 +74,7 @@ export function useManifestStatus() {
   const requiredManifestTables = [
     'DestinyDamageTypeDefinition',
     'DestinyInventoryItemDefinition',
+    'DestinySandboxPerkDefinition',
     'DestinyStatDefinition',
   ];
 

--- a/app/_interfaces/BungieAPI/GetFullProfileResponse.interface.ts
+++ b/app/_interfaces/BungieAPI/GetFullProfileResponse.interface.ts
@@ -9,25 +9,17 @@ export interface GetFullProfileType {
 
 export interface GetFullProfileResponseType {
   characters: {
-    data: {
-      [key: string]: CharacterDataType;
-    };
+    data: Record<string, CharacterDataType>;
   };
   characterEquipment: {
-    data: {
-      [key: string]: CharacterEquipmentType;
-    };
+    data: Record<string, CharacterEquipmentType>;
   };
   itemComponents: {
     instances: {
-      data: {
-        [key: string]: ItemInstanceType;
-      };
+      data: Record<string, ItemInstanceType>;
     };
     perks: {
-      data: {
-        [key: string]: ItemPerkType;
-      };
+      data: Record<string, {perks: ItemPerkType[]}>
     };
   };
 }

--- a/app/_interfaces/BungieAPI/GetFullProfileResponse.interface.ts
+++ b/app/_interfaces/BungieAPI/GetFullProfileResponse.interface.ts
@@ -1,6 +1,7 @@
 import CharacterDataType from '../CharacterData.interface';
 import CharacterEquipmentType from '../CharacterEquipment.interface';
 import ItemInstanceType from '../InventoryItemInstance.interface';
+import ItemPerkType from '../ItemPerk.interface';
 
 export interface GetFullProfileType {
   Response: GetFullProfileResponseType;
@@ -21,6 +22,11 @@ export interface GetFullProfileResponseType {
     instances: {
       data: {
         [key: string]: ItemInstanceType;
+      };
+    };
+    perks: {
+      data: {
+        [key: string]: ItemPerkType;
       };
     };
   };

--- a/app/_interfaces/ItemPerk.interface.ts
+++ b/app/_interfaces/ItemPerk.interface.ts
@@ -1,0 +1,6 @@
+export default interface ItemPerkType {
+  perkHash: number;
+  iconPath: string;
+  isActive: boolean;
+  visible: boolean;
+}

--- a/app/_interfaces/Manifest.interface.ts
+++ b/app/_interfaces/Manifest.interface.ts
@@ -1,9 +1,11 @@
 import { DamageTableType } from './manifestTables/DestinyDamageTypeDefinition.interface';
 import { ItemTableType } from './manifestTables/DestinyInventoryItemDefinition.interface';
 import { StatTableType } from './manifestTables/DestinyStatDefinition.interface';
+import { PerkTableType } from './manifestTables/DestinySandboxPerkDefinition.interface';
 
 export default interface ManifestType {
   DestinyDamageTypeDefinition: DamageTableType;
   DestinyInventoryItemDefinition: ItemTableType;
+  DestinySandboxPerkDefinition: PerkTableType;
   DestinyStatDefinition: StatTableType;
 }

--- a/app/_interfaces/PlayerContext.interface.ts
+++ b/app/_interfaces/PlayerContext.interface.ts
@@ -1,7 +1,9 @@
 import ItemInstanceType from './InventoryItemInstance.interface';
 import CharacterEquipmentType from './CharacterEquipment.interface';
+import ItemPerkType from './ItemPerk.interface';
 
 export default interface PlayerContextType {
   characterEquipment: Record<string, CharacterEquipmentType>;
   itemInstances: Record<string, ItemInstanceType>;
+  itemPerks: Record<string, { perks: ItemPerkType[] }>;
 }

--- a/app/_interfaces/manifestTables/DestinySandboxPerkDefinition.interface.ts
+++ b/app/_interfaces/manifestTables/DestinySandboxPerkDefinition.interface.ts
@@ -1,0 +1,18 @@
+export interface PerkType {
+  blacklisted: boolean;
+  damageType: number;
+  displayProperties: {
+    description: string;
+    hasIcon: boolean;
+    icon?: string;
+    name: string;
+  };
+  hash: number;
+  index: number;
+  isDisplayable: boolean;
+  redacted: boolean;
+}
+
+export interface PerkTableType {
+  [key: number]: PerkType;
+}

--- a/app/api/get-full-profile/route.ts
+++ b/app/api/get-full-profile/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { membershipType, membershipId } = body;
     const response = await fetch(
-      `https://www.bungie.net/platform/Destiny2/${membershipType}/Profile/${membershipId}/?components=205,300`,
+      `https://www.bungie.net/platform/Destiny2/${membershipType}/Profile/${membershipId}/?components=205,300,302`,
       {
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
This PR does most of the heavy lifting for displaying item perk information inside item components:

- Adds the appropriate component to the "full-profile" API request to receive perk info for a given user.
- Adds the appropriate manifest table to be able to look up a perk by its hash and receive detailed information.
- Adds a space in each item component for displaying the icons for the perks present on that item.
- Looks up each perk in the manifest and save its information in a variable.

Somewhere further down the road, I'd like to pick up where this PR leaves off by creating a tooltip on hover that describes what a given perk does.  In the meantime, this should still improve the user experience of the app by providing at least partial information about the specific instances of the items that a character has equipped.